### PR TITLE
Update version of csstime. It supports custom variables for SASS/LESS preprocessors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"csstime-gulp-tasks": "^6.0.2",
+		"csstime-gulp-tasks": "^6.1.0",
 		"pretty-hrtime": "^1.0.1",
 		"gulp": "^3.9.0"
 	},


### PR DESCRIPTION
New option in config:

``` javascript
{
  variables: {
    MY_VARIABLE: 'fancy'
  }
}
```

It will generate variables for preprocessors like:

```
$MY_VARIABLE: "fancy";
```

PR for csstime: https://github.com/csstime/csstime-gulp-tasks/pull/35
