### PR TITLE
Release 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "catberry-assets",
-	"version": "4.0.2",
+	"version": "4.1.0",
 	"author": {
 		"name": "Denis Rechkunov",
 		"email": "denis.rechkunov@gmail.com"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"csstime-gulp-tasks": "^6.0.2",
+		"csstime-gulp-tasks": "^6.1.0",
 		"pretty-hrtime": "^1.0.1",
 		"gulp": "^3.9.0"
 	},


### PR DESCRIPTION
- Update csstime to [6.1.0](https://github.com/csstime/csstime-gulp-tasks/releases/tag/6.1.0)
